### PR TITLE
Map controls are always visible

### DIFF
--- a/src/theme/index.less
+++ b/src/theme/index.less
@@ -38,11 +38,11 @@ img.thumb {
 
 /* ol customizations */
 
-.ol-overlaycontainer {
+.ol-overlaycontainer-stopevent {
   opacity: 0;
   .transition(opacity 300ms ease);
 }
 /* not done with :hover because the overlay blocks events and has no height */
-.over .ol-overlaycontainer {
+.over .ol-overlaycontainer-stopevent {
   opacity: 1;
 }


### PR DESCRIPTION
The index page was designed to have the map controls only visible on mouseover. But they are always visible.
