### PR TITLE
Error at npm run deploy time

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "grunt": "0.4.2",
     "grunt-contrib-clean": "0.5.0",
-    "grunt-gh-pages": "0.9.0",
+    "grunt-gh-pages": "0.9.1",
     "q": "0.9.7",
     "grunt-cli": "0.1.11",
     "bower": "1.2.8",


### PR DESCRIPTION
Very often I get this error when running `npm run deploy`:

```
 Pushing
Warning: To git@github.com:openlayers/openlayers.github.io.git
 ! [rejected]        master -> master (non-fast-forward)
error: failed to push some refs to 'git@github.com:openlayers/openlayers.github.io.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Merge the remote changes (e.g. 'git pull')
hint: before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 Use --force to continue.

Aborted due to warnings.

npm ERR! openlayers-website@0.0.1 deploy: `grunt deploy --treeish 'origin/master'`
npm ERR! Exit status 3
npm ERR! 
npm ERR! Failed at the openlayers-website@0.0.1 deploy script.
npm ERR! This is most likely a problem with the openlayers-website package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     grunt deploy --treeish 'origin/master'
npm ERR! You can get their info via:
npm ERR!     npm owner ls openlayers-website
npm ERR! There is likely additional logging output above.
npm ERR! System Linux 3.8.0-35-generic
npm ERR! command "/home/elemoine/local/bin/node" "/home/elemoine/local/bin/npm" "run" "deploy"
npm ERR! cwd /home/elemoine/src/openlayers.github.io
npm ERR! node -v v0.11.11-pre
npm ERR! npm -v 1.3.22
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/elemoine/src/openlayers.github.io/npm-debug.log
npm ERR! not ok code 0
```

To fix the problem I need to cd to `.grunt/grunt-gh-pages/gh-pages/src/` and do:

```
git fetch origin
git reset --hard origin/master
```
