### PR TITLE
Set the jquery version to 1.11.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "openlayers.github.io",
   "version": "0.0.0",
   "dependencies": {
+    "jquery": "1.11.2",
     "bootstrap": "3.1.1",
     "font-awesome": "3.2.1"
   }


### PR DESCRIPTION
Some jquery version (2.0.3 at least) are not compatible with our build system because they don't have the `dist` directory.

Fixes #23 

See also #25 