### PR TITLE
Don't copy 'resources' directory anymore

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -80,10 +80,6 @@ module.exports = function(grunt) {
       css: {
         src: repo + '/build/hosted/HEAD/css',
         dest: dist + '/en/' + branch + '/css'
-      },
-      resources: {
-        src: repo + '/build/hosted/HEAD/resources',
-        dest: dist + '/en/' + branch + '/resources'
       }
     },
     less: {


### PR DESCRIPTION
The directory has be moved to examples, See https://github.com/openlayers/ol3/pull/3558