### PR TITLE
Change nav bar code link to latest release

### DIFF
--- a/src/layouts/main.hbs
+++ b/src/layouts/main.hbs
@@ -29,7 +29,7 @@
             <li><a href='/en/{{ latest }}/doc'{{#is section 'Docs'}}class="active"{{/is}}>Docs</a></li>
             <li><a href='/en/{{ latest }}/examples'>Examples</a></li>
             <li><a href='/en/{{ latest }}/apidoc'>API</a></li>
-            <li><a href='https://github.com/openlayers/ol3'>Code</a></li>
+            <li><a href='https://github.com/openlayers/ol3/tree/{{ latest }}'>Code</a></li>
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
As the docs/examples/api links in the header all point to the latest release, ISTM it would be more logical for the 'code' link to point to the release tag on Github rather than master.