### PR TITLE
Update the OpenLayers 2 home page

### DIFF
--- a/src/two/index.html
+++ b/src/two/index.html
@@ -115,17 +115,7 @@
 
     <h3><a href="http://blog.openlayers.org/2012/11/01/crowdfunding-openlayers-3/">Introducing OpenLayers 3!</a></h3>
 
-    <p>We've begun the development effort to make the next major version of OpenLayers a reality. <a href="http://openlayers.org">OpenLayers 3</a> is a comprehensive rewrite of the library, targeting the latest in HTML5 and CSS3 features. The library will continue to have broad support for projections, standard protocols, and editing functionality from OpenLayers 2.x. The new version of the library will focus on performance improvements, lighter builds, prettier visual components, an improved API, and more.</p>
-    <p>Some of the major highlights are:
-
-    <ul style="font-size:.9em;margin-top:0px;">
-      <li><strong><a href="http://en.wikipedia.org/wiki/WebGL">WebGL</a></strong> promises to bring 3D capabilities and increased performance for all mapping needs to the latest browsers. OpenLayers 3.0 will offer WebGL, while degrading nicely in less capable browsers.</li>
-      <li><strong><a href="http://cesium.agi.com/">Cesium</a></strong>: The OpenLayers community will also integrate the new Cesium library to enable full 3D spinning globe capabilities directly into the 3.0 release.</li>
-      <li><strong><a href="http://developers.google.com/closure/compiler/">Closure Compiler</a></strong>: By utilizing the Closure Compiler, applications developers will be able to create smaller and faster libraries, easing the use of the extensive OpenLayers 3.0 toolkit.</li>
-      <li><strong>A new codebase</strong>: This offers an opportunity to clean up some of the “clunky” ways of doing things in OpenLayers. The team will also create with new API designs, which will be more accessible to all.</li>
-      <li><strong>High-quality documentation</strong>: The new release will also feature documentation with fresh examples and default designs in OpenLayers 3.0. Making a toolkit standout is about more than the actual code.</li>
-    </ul>
-    </p>
+    <p><a href="http://openlayers.org">OpenLayers 3</a> is a comprehensive rewrite of the library, targeting the latest in HTML5 and CSS3 features. The library continues to have broad support for projections, standard protocols, and editing functionality. The new version of the library focuses on performance improvements, lighter builds, prettier visual components, an improved API, and more.</p>
 
     <h3>For Developers!</h3>
     <p>OpenLayers is a pure JavaScript library for displaying map data in most modern web browsers, with no server-side dependencies. OpenLayers implements a <a href="http://trac.openlayers.org/wiki/Documentation">JavaScript API</a> for building rich web-based geographic applications, similar to the Google Maps APIs, with one important difference -- OpenLayers is Free Software, developed for and by the Open Source software community.</p>
@@ -134,7 +124,7 @@
 
     <p>Releases are made available on the <a href="http://github.com/openlayers/openlayers/releases">downloads</a> page.  The code is also available in our <a href="http://github.com/openlayers/openlayers">Git repository</a>. With a clone of the Git repository, you can keep up with the latest and contribute patches to OpenLayers.</p>
 
-    <p>If you don't want to download the code, you can still try some of the <a href="/dev/examples/">hosted examples</a>. If you're familiar with JavaScript, try viewing the source of the examples to get an idea how the OpenLayers library is used.</p>
+    <p>If you don't want to download the code, you can still try some of the <a href="http://dev.openlayers.org/examples/">hosted examples</a>. If you're familiar with JavaScript, try viewing the source of the examples to get an idea how the OpenLayers library is used.</p>
 
     <h3>Other Resources</h3>
 
@@ -197,4 +187,3 @@
   </script>
   </body>
 </html>
-


### PR DESCRIPTION
Fixes a link to the example pages, and does not talk about OpenLayers 3 like it was a not existent yet any more.

Fixes openlayers/openlayers.github.io#54