### PR TITLE
Don't process resources when assembling documentation

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -122,6 +122,18 @@ module.exports = function(grunt) {
           src: 'src/builder/builder.js',
           dest: dist + '/en/' + branch + '/builder/builder.js'
         }]
+      },
+      doc: {
+        files: [{
+          expand: true,
+          cwd: repo,
+          src: [
+            'doc/**/*.*',
+            '!doc/**/*.hbs',
+            '!doc/**/*.md',
+          ],
+          dest: dist + '/en/' + branch
+        }]
       }
     },
     assemble: {
@@ -151,7 +163,7 @@ module.exports = function(grunt) {
         files: [{
           expand: true,
           cwd: repo,
-          src: 'doc/**/*.*',
+          src: ['doc/**/*.hbs', 'doc/**/*.md'],
           dest: dist + '/en/' + branch
         }]
       }


### PR DESCRIPTION
This PR fixes issue that appears when deploying documentation with resources -- all the files in `doc` are assembled (including images) and it fails -- see https://github.com/openlayers/ol3/pull/4440#issuecomment-157988469.

I modified the tasks to assemble only `.hbs` and `.md` files and added rule to simply copy all other files.