### PR TITLE
Rename the openlayers GitHub project to ol2

### DIFF
--- a/src/api/2.12/OpenLayers.debug.js
+++ b/src/api/2.12/OpenLayers.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -56120,7 +56120,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 if (style.graphicTitle) {
                     node.setAttributeNS(null, "title", style.graphicTitle);
                     //Standards-conformant SVG
-                    // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+                    // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
                     var titleNode = node.getElementsByTagName("title");
                     if (titleNode.length > 0) {
                         titleNode[0].firstChild.textContent = style.graphicTitle;
@@ -63093,7 +63093,7 @@ OpenLayers.Marker.Box = OpenLayers.Class(OpenLayers.Marker, {
     * sz - {<OpenLayers.Size>} 
     * 
     * Returns: 
-    * {DOMElement} A new DOM Image with this marker´s icon set at the 
+    * {DOMElement} A new DOM Image with this markerï¿½s icon set at the 
     *         location passed-in
     */
     draw: function(px, sz) {
@@ -71867,7 +71867,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             // Force a reflow before calling setCenter. This is to work
             // around an issue occuring in iOS.
             //
-            // See https://github.com/openlayers/openlayers/pull/351.
+            // See https://github.com/openlayers/ol2/pull/351.
             //
             // Without a reflow setting the layer container div's top left
             // style properties to "0px" - as done in Map.moveTo when zoom

--- a/src/api/2.12/OpenLayers.js
+++ b/src/api/2.12/OpenLayers.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.12/OpenLayers.light.debug.js
+++ b/src/api/2.12/OpenLayers.light.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -28380,7 +28380,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 if (style.graphicTitle) {
                     node.setAttributeNS(null, "title", style.graphicTitle);
                     //Standards-conformant SVG
-                    // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+                    // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
                     var titleNode = node.getElementsByTagName("title");
                     if (titleNode.length > 0) {
                         titleNode[0].firstChild.textContent = style.graphicTitle;

--- a/src/api/2.12/OpenLayers.light.js
+++ b/src/api/2.12/OpenLayers.light.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.12/OpenLayers.mobile.debug.js
+++ b/src/api/2.12/OpenLayers.mobile.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -36148,7 +36148,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
                 if (style.graphicTitle) {
                     node.setAttributeNS(null, "title", style.graphicTitle);
                     //Standards-conformant SVG
-                    // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+                    // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
                     var titleNode = node.getElementsByTagName("title");
                     if (titleNode.length > 0) {
                         titleNode[0].firstChild.textContent = style.graphicTitle;
@@ -39920,7 +39920,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             // Force a reflow before calling setCenter. This is to work
             // around an issue occuring in iOS.
             //
-            // See https://github.com/openlayers/openlayers/pull/351.
+            // See https://github.com/openlayers/ol2/pull/351.
             //
             // Without a reflow setting the layer container div's top left
             // style properties to "0px" - as done in Map.moveTo when zoom

--- a/src/api/2.12/OpenLayers.mobile.js
+++ b/src/api/2.12/OpenLayers.mobile.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.12/theme/default/style.mobile.css
+++ b/src/api/2.12/theme/default/style.mobile.css
@@ -54,7 +54,7 @@ div.olControlZoom a:hover {
    http://osgeo-org.1803224.n2.nabble.com/Harware-accelerated-CSS3-animations-for-iOS-td6255560.html
 
    It also prevents tile blinking effects in iOS 5.
-   See https://github.com/openlayers/openlayers/issues/511
+   See https://github.com/openlayers/ol2/issues/511
 */
 @media (-webkit-transform-3d) {
 img.olTileImage {

--- a/src/api/2.13.1/OpenLayers.debug.js
+++ b/src/api/2.13.1/OpenLayers.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -57306,7 +57306,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         if (title) {
             node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
-            // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+            // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
                 titleNode[0].firstChild.textContent = title;
@@ -74516,7 +74516,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             // Force a reflow before calling setCenter. This is to work
             // around an issue occuring in iOS.
             //
-            // See https://github.com/openlayers/openlayers/pull/351.
+            // See https://github.com/openlayers/ol2/pull/351.
             //
             // Without a reflow setting the layer container div's top left
             // style properties to "0px" - as done in Map.moveTo when zoom

--- a/src/api/2.13.1/OpenLayers.js
+++ b/src/api/2.13.1/OpenLayers.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.13.1/OpenLayers.light.debug.js
+++ b/src/api/2.13.1/OpenLayers.light.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -29213,7 +29213,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         if (title) {
             node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
-            // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+            // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
                 titleNode[0].firstChild.textContent = title;

--- a/src/api/2.13.1/OpenLayers.light.js
+++ b/src/api/2.13.1/OpenLayers.light.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.13.1/OpenLayers.mobile.debug.js
+++ b/src/api/2.13.1/OpenLayers.mobile.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -36846,7 +36846,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         if (title) {
             node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
-            // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+            // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
                 titleNode[0].firstChild.textContent = title;
@@ -40602,7 +40602,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             // Force a reflow before calling setCenter. This is to work
             // around an issue occuring in iOS.
             //
-            // See https://github.com/openlayers/openlayers/pull/351.
+            // See https://github.com/openlayers/ol2/pull/351.
             //
             // Without a reflow setting the layer container div's top left
             // style properties to "0px" - as done in Map.moveTo when zoom

--- a/src/api/2.13.1/OpenLayers.mobile.js
+++ b/src/api/2.13.1/OpenLayers.mobile.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.13/OpenLayers.debug.js
+++ b/src/api/2.13/OpenLayers.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -57300,7 +57300,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         if (title) {
             node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
-            // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+            // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
                 titleNode[0].firstChild.textContent = title;
@@ -74510,7 +74510,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             // Force a reflow before calling setCenter. This is to work
             // around an issue occuring in iOS.
             //
-            // See https://github.com/openlayers/openlayers/pull/351.
+            // See https://github.com/openlayers/ol2/pull/351.
             //
             // Without a reflow setting the layer container div's top left
             // style properties to "0px" - as done in Map.moveTo when zoom

--- a/src/api/2.13/OpenLayers.js
+++ b/src/api/2.13/OpenLayers.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.13/OpenLayers.light.debug.js
+++ b/src/api/2.13/OpenLayers.light.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -29207,7 +29207,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         if (title) {
             node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
-            // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+            // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
                 titleNode[0].firstChild.textContent = title;

--- a/src/api/2.13/OpenLayers.light.js
+++ b/src/api/2.13/OpenLayers.light.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/2.13/OpenLayers.mobile.debug.js
+++ b/src/api/2.13/OpenLayers.mobile.debug.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 
@@ -36840,7 +36840,7 @@ OpenLayers.Renderer.SVG = OpenLayers.Class(OpenLayers.Renderer.Elements, {
         if (title) {
             node.setAttributeNS(null, "title", title);
             //Standards-conformant SVG
-            // Prevent duplicate nodes. See issue https://github.com/openlayers/openlayers/issues/92 
+            // Prevent duplicate nodes. See issue https://github.com/openlayers/ol2/issues/92 
             var titleNode = node.getElementsByTagName("title");
             if (titleNode.length > 0) {
                 titleNode[0].firstChild.textContent = title;
@@ -40596,7 +40596,7 @@ OpenLayers.Control.PinchZoom = OpenLayers.Class(OpenLayers.Control, {
             // Force a reflow before calling setCenter. This is to work
             // around an issue occuring in iOS.
             //
-            // See https://github.com/openlayers/openlayers/pull/351.
+            // See https://github.com/openlayers/ol2/pull/351.
             //
             // Without a reflow setting the layer container div's top left
             // style properties to "0px" - as done in Map.moveTo when zoom

--- a/src/api/2.13/OpenLayers.mobile.js
+++ b/src/api/2.13/OpenLayers.mobile.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/OpenLayers.js
+++ b/src/api/OpenLayers.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/OpenLayers.light.js
+++ b/src/api/OpenLayers.light.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/api/OpenLayers.mobile.js
+++ b/src/api/OpenLayers.mobile.js
@@ -9,7 +9,7 @@
   Includes compressed code under the following licenses:
 
   (For uncompressed versions of the code used, please see the
-  OpenLayers Github repository: <https://github.com/openlayers/openlayers>)
+  OpenLayers Github repository: <https://github.com/openlayers/ol2>)
 
 */
 

--- a/src/two/index.html
+++ b/src/two/index.html
@@ -103,11 +103,11 @@
     </h2>
     <h3>Where to get OpenLayers 2:</h3>
     <ul style="font-size:.9em;margin-top:0px;">
-      <li>2.13.1 (Stable): <a href="http://github.com/openlayers/openlayers/releases/download/release-2.13.1/OpenLayers-2.13.1.tar.gz">.tar.gz</a> | <a href="http://github.com/openlayers/openlayers/releases/download/release-2.13.1/OpenLayers-2.13.1.zip">.zip</a></li>
-      <li><a href="http://github.com/openlayers/openlayers/blob/master/notes/2.13.md">2.13.1 Release Notes</a></li>
+      <li>2.13.1 (Stable): <a href="http://github.com/openlayers/ol2/releases/download/release-2.13.1/OpenLayers-2.13.1.tar.gz">.tar.gz</a> | <a href="http://github.com/openlayers/ol2/releases/download/release-2.13.1/OpenLayers-2.13.1.zip">.zip</a></li>
+      <li><a href="http://github.com/openlayers/ol2/blob/master/notes/2.13.md">2.13.1 Release Notes</a></li>
       <li><a href="http://dev.openlayers.org/releases/OpenLayers-2.13.1/doc/apidocs/files/OpenLayers-js.html">API Documentation</a>, <a href="http://trac.openlayers.org/wiki/Documentation">User documentation</a></li>
       <li>See examples of OpenLayers 2 Usage: <a href="http://dev.openlayers.org/examples/">Development Examples</a>, <a href="http://dev.openlayers.org/releases/OpenLayers-2.13.1/examples/">2.13.1 Release Examples</a></li>
-      <li>Fork us on <a href="http://github.com/openlayers/openlayers">GitHub</a></li>
+      <li>Fork us on <a href="http://github.com/openlayers/ol2">GitHub</a></li>
     </ul>
 
     <h3>About OpenLayers</h3>
@@ -122,7 +122,7 @@
 
     <h3>Getting the Code</h3>
 
-    <p>Releases are made available on the <a href="http://github.com/openlayers/openlayers/releases">downloads</a> page.  The code is also available in our <a href="http://github.com/openlayers/openlayers">Git repository</a>. With a clone of the Git repository, you can keep up with the latest and contribute patches to OpenLayers.</p>
+    <p>Releases are made available on the <a href="http://github.com/openlayers/ol2/releases">downloads</a> page.  The code is also available in our <a href="http://github.com/openlayers/ol2">Git repository</a>. With a clone of the Git repository, you can keep up with the latest and contribute patches to OpenLayers.</p>
 
     <p>If you don't want to download the code, you can still try some of the <a href="http://dev.openlayers.org/examples/">hosted examples</a>. If you're familiar with JavaScript, try viewing the source of the examples to get an idea how the OpenLayers library is used.</p>
 


### PR DESCRIPTION
As already discussed at the FOSS4G conference in Seoul, it is time to make OpenLayers 3 known as just OpenLayers instead of ol3. For this purpose, the openlayers project on GitHub (OpenLayers 2) should be renamed to ol2.

Just before this pull request is merged, the https://github.com/openlayers/openlayers repository on GitHub should be renamed.