### PR TITLE
ZIP improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /.grunt/
+*.zip

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -215,18 +215,20 @@ module.exports = function(grunt) {
         src: [
           dist + '/en/' + branch + '/**/*'
         ],
-        dest: branch + '.zip'
+        dest: branch + '.zip',
+        compression: 'DEFLATE'
       },
       dist: {
         src: [
           dist + '/en/' + branch + '/build/ol.js',
           dist + '/en/' + branch + '/build/ol-debug.js',
-          dist + '/en/' + branch + '/css/ol.css'
+          dist + '/en/' + branch + '/css/ol.css',
         ],
         router: function(filepath) {
           return branch + '-dist/' + path.basename(filepath);
         },
-        dest: branch + '-dist.zip'
+        dest: branch + '-dist.zip',
+        compression: 'DEFLATE'
       }
     }
   });


### PR DESCRIPTION
The archives created by the `grunt zip` task have insanely huge file size. This can be fixed by using the "DEFLATE" mode.

It also makes sense to ignore the created zip archives in the root, to avoid accidentally committing them.