### PR TITLE
Add a robots.txt file, only allow latest

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -142,6 +142,17 @@ module.exports = function(grunt) {
         assets: assets,
         latest: latest
       },
+      robots: {
+        options: {
+          ext: '.txt'
+        },
+        files: [{
+          expand: true,
+          cwd: 'src',
+          src: 'robots.hbs',
+          dest: dist
+        }]
+      },
       pages: {
         files: [{
           expand: true,

--- a/src/robots.hbs
+++ b/src/robots.hbs
@@ -1,0 +1,3 @@
+user-agent: *
+disallow: /en/
+allow: /en/{{ latest }}/


### PR DESCRIPTION
This is a partial solution to get old examples and docs to drop out of Google's index.

Currently, searches for examples return results from multiple versions, making it easy to get outdated or bad info.  For example, https://www.google.com/search?q=openlayers+layer+spy+example currently returns http://openlayers.org/en/v3.1.0/examples/layer-spy.html as the top result (and this example is not working).

This branch adds a `robots.txt` file at the root instructing bots only to follow links into the latest release.  For example, currently this renders to:

```
user-agent: *
disallow: /en/
allow: /en/v3.14.0/
```

(See [the documentation on precedence](https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt#order-of-precedence-for-group-member-records) with `allow` and `disallow`.)

This will not keep docs from getting indexed where there are incoming links elsewhere on the web.  We could improve the situation there by adding `<meta name="robots" content="noindex,nofollow">` to outdated versions, but this would require an overhaul in how the site is built.

See also https://developers.google.com/webmasters/control-crawl-index/docs/faq#h17
