### PR TITLE
Use a div instead of an alert box for old version warnings

### DIFF
--- a/en/v3.0.0/apidoc/scripts/main.js
+++ b/en/v3.0.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // show/hide unstable items
     var unstable = $('.unstable');

--- a/en/v3.1.0/apidoc/scripts/main.js
+++ b/en/v3.1.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // show/hide unstable items
     var links = $('a[href^="ol."]');

--- a/en/v3.1.1/apidoc/scripts/main.js
+++ b/en/v3.1.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // show/hide unstable items
     var links = $('a[href^="ol."]');

--- a/en/v3.10.0/apidoc/scripts/main.js
+++ b/en/v3.10.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.10.1/apidoc/scripts/main.js
+++ b/en/v3.10.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.11.0/apidoc/scripts/main.js
+++ b/en/v3.11.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.11.1/apidoc/scripts/main.js
+++ b/en/v3.11.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.11.2/apidoc/scripts/main.js
+++ b/en/v3.11.2/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.12.0/apidoc/scripts/main.js
+++ b/en/v3.12.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.12.1/apidoc/scripts/main.js
+++ b/en/v3.12.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.13.0/apidoc/scripts/main.js
+++ b/en/v3.13.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.13.1/apidoc/scripts/main.js
+++ b/en/v3.13.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.14.0/apidoc/scripts/main.js
+++ b/en/v3.14.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.14.1/apidoc/scripts/main.js
+++ b/en/v3.14.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.14.2/apidoc/scripts/main.js
+++ b/en/v3.14.2/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.15.0/apidoc/scripts/main.js
+++ b/en/v3.15.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.15.1/apidoc/scripts/main.js
+++ b/en/v3.15.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.2.0/apidoc/scripts/main.js
+++ b/en/v3.2.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // show/hide unstable items
     var links = $('a[href^="ol."]');

--- a/en/v3.2.1/apidoc/scripts/main.js
+++ b/en/v3.2.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // show/hide unstable items
     var links = $('a[href^="ol."]');

--- a/en/v3.3.0/apidoc/scripts/main.js
+++ b/en/v3.3.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // show/hide unstable items
     var links = $('a[href^="ol."]');

--- a/en/v3.4.0/apidoc/scripts/main.js
+++ b/en/v3.4.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.5.0/apidoc/scripts/main.js
+++ b/en/v3.5.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.6.0/apidoc/scripts/main.js
+++ b/en/v3.6.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.7.0/apidoc/scripts/main.js
+++ b/en/v3.7.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.8.1/apidoc/scripts/main.js
+++ b/en/v3.8.1/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.8.2/apidoc/scripts/main.js
+++ b/en/v3.8.2/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');

--- a/en/v3.9.0/apidoc/scripts/main.js
+++ b/en/v3.9.0/apidoc/scripts/main.js
@@ -54,22 +54,45 @@ $(function () {
     _onResize();
 
     // warn about outdated version
-    var srcLinks = $('div.tag-source');
-    var location = window.location.href;
-    var branchSearch = location.match(/\/([^\/]*)\/apidoc\//);
-    if (branchSearch && branchSearch.length) {
-      var branch = branchSearch[1];
-      if (branch !== 'latest') {
-        if (/^v[0-9\.]*$/.test(branch)) {
-          var ok = confirm('You are viewing outdated docs. Do you want to try the latest?');
-          if (ok) {
-            window.location.href = location.replace(branchSearch[0], '/latest/apidoc/');
-          }
-        } else {
-          $('.package-version').text(branch);
+    var packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', packageUrl);
+    xhr.onload = function(response) {
+      var json = JSON.parse(xhr.responseText);
+      var latestVersion = json.version;
+      var url = window.location.href;
+      var branchSearch = url.match(/\/v([^\/]*)\/apidoc\//);
+      var currentVersion = branchSearch[1];
+      var cookieText = 'dismissed=-' + latestVersion + '-';
+      var dismissed = document.cookie.indexOf(cookieText) != -1;
+      if (!dismissed && /^[0-9\.]*$/.test(currentVersion) && currentVersion != latestVersion) {
+        var link = url.replace(branchSearch[0], '/latest/apidoc/');
+        var linkXhr = new XMLHttpRequest();
+        linkXhr.open('HEAD', link);
+        linkXhr.onload = function(response) {
+          var a = document.getElementById('latest-link');
+          a.href = linkXhr.status == 200 ? link : '../../latest/apidoc/';
+        };
+        linkXhr.send();
+        var latestCheck = document.createElement('div');
+        latestCheck.style.marginTop = '-10px';
+        latestCheck.style.marginBottom = '10px';
+        latestCheck.className = 'alert alert-warning alert-dismissable';
+        latestCheck.role = 'alert';
+        latestCheck.innerHTML = '<button id="latest-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close">' +
+            '<span aria-hidden="true">&times;</span></button>' +
+            'This documentation is for OpenLayers v<span id="package-version">' + currentVersion + '</span>. ' +
+            'The <a id="latest-link" href="#" class="alert-link">latest</a> is v<span id="latest-version"></span>.';
+        var alertContainer = document.getElementById('wrap').lastElementChild;
+        alertContainer.insertBefore(latestCheck, alertContainer.childNodes[0]);
+        document.getElementById('latest-version').innerHTML = latestVersion;
+        document.getElementById('latest-dismiss').onclick = function() {
+          latestCheck.style.display = 'none';
+          document.cookie = cookieText;
         }
       }
-    }
+    };
+    xhr.send();
 
     // create source code links to github
     var srcLinks = $('div.tag-source');


### PR DESCRIPTION
This addresses feedback from https://www.google.com/url?hl=en&q=https://groups.google.com/d/msgid/ol3-dev/524d4154-2923-4697-a922-f73ff0d9827d%2540googlegroups.com&source=gmail&ust=1463153396990000&usg=AFQjCNGzjKOEn84U9kAR_ehvmTHvs97XOg.

It also makes the box smarter by linking to the apidocs main page instead of the specific page if the page is not available any more in the latest version.

See openlayers/ol3#5339 for how this will look.