### PR TITLE
Make sure anchor targets are not covered by the navbar

### DIFF
--- a/src/theme/site.less
+++ b/src/theme/site.less
@@ -65,6 +65,14 @@ footer a:focus {
   color: white;
 }
 
+/* Move anchor targets down so they are not covered by the navbar */
+:target:before {
+  content: "";
+  display: block;
+  height: 50px;
+  margin-top: -50px;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
When navigating to an anchor target, the target is covered by the navbar. See e.g. http://openlayers.org/en/latest/doc/faq.html#why-is-my-map-centered-on-the-gulf-of-guinea-or-africa-the-ocean-null-island-.