### PR TITLE
s/ol3-layerswitcher/ol-layerswitcher/

### DIFF
--- a/src/pages/3rd-party/index.hbs
+++ b/src/pages/3rd-party/index.hbs
@@ -28,7 +28,7 @@ layout: main.hbs
             <td><a href="https://github.com/openlayers">OpenLayers</a></td>
           </tr>
           <tr>
-            <td><a href="https://github.com/walkermatt/ol3-layerswitcher">OL3-LayerSwitcher</a></td>
+            <td><a href="https://github.com/walkermatt/ol-layerswitcher">OL-LayerSwitcher</a></td>
             <td>Layer control for OpenLayers.</td>
             <td><a href="https://github.com/walkermatt">Matt Walker</a></td>
           </tr>


### PR DESCRIPTION
I've renamed ol3-layerswitcher to ol-layerswitcher since adding support for the `ol` package.