### PR TITLE
List older versions of OpenLayers on main page

### DIFF
--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -16,7 +16,6 @@ head:
     <div id='news' class='col-sm-12'>
       <h1 class='topic'><i class='fa fa-rss'></i> Latest</h1>
       <p><strong>OpenLayers <a href="https://openlayers.org/download/">{{ latest }}</a> is here!</strong> Check out the <a href="en/latest/doc/">docs</a> and the <a href="en/latest/examples/">examples</a> to get started. The full distribution can be downloaded from the <a href="https://openlayers.org/download/">release page</a>.</p>
-      <p>If you've come here looking for OpenLayers 2.x information, you'll find everything you need on the <a href="./two">2.x page</a>.</p>
     </div>
   </div>
   <div class='row'>
@@ -83,6 +82,19 @@ head:
         <h3><i class='fa fa-sitemap'></i> API Docs</h3>
         <p>Browse through the API docs for details on code usage.</p>
       </a>
+    </div>
+  </div>
+  <div class='row'>
+    <h1 class='topic col-sm-12'>Older versions</h1>
+    <div class='col-sm-12'>
+      <p>In case you are not ready (yet) for the latest version of OpenLayers, we provide links to selected resources of older major versions of the software.</p>
+      <ul>
+        <li>Latest v4: <a href="https://github.com/openlayers/openlayers/releases/tag/v4.6.5">v4.6.5</a> released 2017-03-20 &mdash; <a href="/en/v4.6.5/doc/">docs</a>, <a href="/en/v4.6.5/apidoc/">API</a> &amp;  <a href="/en/v4.6.5/examples/">examples</a></li>
+        <li>Latest v3: <a href="https://github.com/openlayers/openlayers/releases/tag/v3.20.1">v3.20.1</a>, released 2016-12-12 &mdash; <a href="/en/v3.20.1/doc/">docs</a>, <a href="/en/v3.20.1/apidoc/">API</a> &amp;  <a href="/en/v3.20.1/examples/">examples</a></li>
+        <li>Latest v2: v2.13.1 (July 2013 i.e. really old) &mdash; you'll find everything you need on the <a href="./two">2.x page</a></li>
+        <li>Latest v1 &mdash; You're kidding, right?</li>
+      </ul>
+      <p>Please consider upgrading to benefit of the latest features and bug fixes. Get best performance and usability for free by using recent versions of OpenLayers</p>
     </div>
   </div>
   <div class='row'>


### PR DESCRIPTION
This adds links to older major version of OpenLayers, since people do not find them easily enough.

![old](https://user-images.githubusercontent.com/227934/45001525-fb0eae80-afcd-11e8-88af-f76a28bb8869.png)
