### PR TITLE
Clarify the readme to specify that this is the compiled code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 # OpenLayers Website
 
-This repository is the source for the https://openlayers.org website.  Commits to the default branch (`main`) trigger a deploy.  The contents of the `dist` directory will be published to the website.
+This repository powers the https://openlayers.org website - the contents of the `dist` directory will be published to the website.  Commits to the default branch (`main`) trigger a deploy.  
+
+To make changes to the source that powers this repository, please make pull requests to the [OpenLayers main repository](https://github.com/openlayers/openlayers/tree/main/site), where you will find the source in the `site/src` folder.


### PR DESCRIPTION
This PR makes a small edit to the README to inform folks that this is the compiled code and not the source for the website and that they can see the source in the main OpenLayers repository.

Happy to change the wording if it doesn't feel quite right.